### PR TITLE
Switch to Devstral via OpenRouter

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 DeepSeek Engineer
+Copyright (c) 2025 Devstral Engineer
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# DeepSeek Engineer v2 🐋
+# Devstral Engineer v2 🐋
 
 ## Overview
 
-DeepSeek Engineer v2 is a powerful AI-powered coding assistant that provides an interactive terminal interface for seamless code development. It integrates with DeepSeek's advanced reasoning models to offer intelligent file operations, code analysis, and development assistance through natural conversation and function calling.
+Devstral Engineer v2 is a powerful AI-powered coding assistant that provides an interactive terminal interface for seamless code development. It integrates with Devstral's advanced reasoning models to offer intelligent file operations, code analysis, and development assistance through natural conversation and function calling.
 
 ## 🚀 Latest Update: Function Calling Architecture
 
@@ -78,7 +78,7 @@ For when you want to preload files into conversation context:
 ## Getting Started
 
 ### Prerequisites
-1. **DeepSeek API Key**: Get your API key from [DeepSeek Platform](https://platform.deepseek.com)
+1. **OpenRouter API Key**: Get your API key from [OpenRouter](https://openrouter.ai)
 2. **Python 3.11+**: Required for optimal performance
 
 ### Installation
@@ -86,13 +86,13 @@ For when you want to preload files into conversation context:
 1. **Clone the repository**:
    ```bash
    git clone <repository-url>
-   cd deepseek-engineer
+   cd devstral-engineer
    ```
 
 2. **Set up environment**:
    ```bash
    # Create .env file
-   echo "DEEPSEEK_API_KEY=your_api_key_here" > .env
+   echo "OPENROUTER_API_KEY=your_api_key_here" > .env
    ```
 
 3. **Install dependencies** (choose one method):
@@ -100,13 +100,13 @@ For when you want to preload files into conversation context:
    #### Using uv (recommended - faster)
    ```bash
    uv venv
-   uv run deepseek-eng.py
+   uv run devstral-eng.py
    ```
 
    #### Using pip
    ```bash
    pip install -r requirements.txt
-   python3 deepseek-eng.py
+   python3 devstral-eng.py
    ```
 
 ### Usage Examples
@@ -165,8 +165,8 @@ You> Now review this codebase structure
 
 ## Technical Details
 
-### **Model**: DeepSeek-Reasoner
-- Powered by DeepSeek-R1 with Chain-of-Thought reasoning
+### **Model**: mistralai/devstral-small:free
+- Powered by Devstral with Chain-of-Thought reasoning
 - Real-time reasoning visibility during processing
 - Enhanced problem-solving capabilities
 
@@ -227,7 +227,7 @@ Based on my analysis of your project, here's a comprehensive refactoring plan...
 **API Key Not Found**
 ```bash
 # Make sure .env file exists with your API key
-echo "DEEPSEEK_API_KEY=your_key_here" > .env
+echo "OPENROUTER_API_KEY=your_key_here" > .env
 ```
 
 **Import Errors**
@@ -242,12 +242,12 @@ uv sync  # or pip install -r requirements.txt
 
 ## Contributing
 
-This is an experimental project showcasing DeepSeek reasoning model capabilities. Contributions are welcome!
+This is an experimental project showcasing Devstral reasoning model capabilities. Contributions are welcome!
 
 ### **Development Setup**
 ```bash
 git clone <repository-url>
-cd deepseek-engineer
+cd devstral-engineer
 uv venv
 uv sync
 ```
@@ -255,20 +255,20 @@ uv sync
 ### **Run**
 ```bash
 # Run the application (preferred)
-uv run deepseek-eng.py
+uv run devstral-eng.py
 ```
 or
 ```bash
-python3 deepseek-eng.py
+python3 devstral-eng.py
 ```
 
 ## License
 
 This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
 
-This project is experimental and developed for testing DeepSeek reasoning model capabilities.
+This project is experimental and developed for testing Devstral reasoning model capabilities.
 
 ---
 
-> **Note**: This is an experimental project developed to explore the capabilities of DeepSeek's reasoning model with function calling. The AI can automatically read files you mention in conversation, while the `/add` command is available for when you want to preload context. Use responsibly and enjoy the enhanced AI pair programming experience! 🚀
+> **Note**: This is an experimental project developed to explore the capabilities of Devstral's reasoning model with function calling. The AI can automatically read files you mention in conversation, while the `/add` command is available for when you want to preload context. Use responsibly and enjoy the enhanced AI pair programming experience! 🚀
 

--- a/devstral-eng.py
+++ b/devstral-eng.py
@@ -32,9 +32,9 @@ prompt_session = PromptSession(
 # --------------------------------------------------------------------------------
 load_dotenv()  # Load environment variables from .env file
 client = OpenAI(
-    api_key=os.getenv("DEEPSEEK_API_KEY"),
-    base_url="https://api.deepseek.com"
-)  # Configure for DeepSeek API
+    base_url="https://openrouter.ai/api/v1",
+    api_key=os.getenv("OPENROUTER_API_KEY"),
+)
 
 # --------------------------------------------------------------------------------
 # 2. Define our schema using Pydantic for type safety
@@ -166,7 +166,7 @@ tools = [
 # 3. system prompt
 # --------------------------------------------------------------------------------
 system_PROMPT = dedent("""\
-    You are an elite software engineer called DeepSeek Engineer with decades of experience across all programming domains.
+    You are an elite software engineer called Devstral Engineer with decades of experience across all programming domains.
     Your expertise spans system design, algorithms, testing, and best practices.
     You provide thoughtful, well-structured solutions while explaining your reasoning.
 
@@ -586,11 +586,16 @@ def stream_openai_response(user_message: str):
     # Remove the old file guessing logic since we'll use function calls
     try:
         stream = client.chat.completions.create(
-            model="deepseek-reasoner",
+            model="mistralai/devstral-small:free",
             messages=conversation_history,
             tools=tools,
             max_completion_tokens=64000,
-            stream=True
+            stream=True,
+            extra_headers={
+                "HTTP-Referer": os.getenv("HTTP_REFERER", ""),
+                "X-Title": os.getenv("SITE_TITLE", "Devstral Engineer"),
+            },
+            extra_body={},
         )
 
         console.print("\n[bold bright_blue]🐋 Seeking...[/bold bright_blue]")
@@ -695,11 +700,16 @@ def stream_openai_response(user_message: str):
                 console.print("\n[bold bright_blue]🔄 Processing results...[/bold bright_blue]")
                 
                 follow_up_stream = client.chat.completions.create(
-                    model="deepseek-reasoner",
+                    model="mistralai/devstral-small:free",
                     messages=conversation_history,
                     tools=tools,
                     max_completion_tokens=64000,
-                    stream=True
+                    stream=True,
+                    extra_headers={
+                        "HTTP-Referer": os.getenv("HTTP_REFERER", ""),
+                        "X-Title": os.getenv("SITE_TITLE", "Devstral Engineer"),
+                    },
+                    extra_body={},
                 )
                 
                 follow_up_content = ""
@@ -734,7 +744,7 @@ def stream_openai_response(user_message: str):
         return {"success": True}
 
     except Exception as e:
-        error_msg = f"DeepSeek API error: {str(e)}"
+        error_msg = f"OpenRouter API error: {str(e)}"
         console.print(f"\n[bold red]❌ {error_msg}[/bold red]")
         return {"error": error_msg}
 
@@ -744,8 +754,8 @@ def stream_openai_response(user_message: str):
 
 def main():
     # Create a beautiful gradient-style welcome panel
-    welcome_text = """[bold bright_blue]🐋 DeepSeek Engineer[/bold bright_blue] [bright_cyan]with Function Calling[/bright_cyan]
-[dim blue]Powered by DeepSeek-R1 with Chain-of-Thought Reasoning[/dim blue]"""
+    welcome_text = """[bold bright_blue]🐋 Devstral Engineer[/bold bright_blue] [bright_cyan]with Function Calling[/bright_cyan]
+[dim blue]Powered by Devstral with Chain-of-Thought Reasoning[/dim blue]"""
     
     console.print(Panel.fit(
         welcome_text,
@@ -796,7 +806,7 @@ def main():
         if response_data.get("error"):
             console.print(f"[bold red]❌ Error: {response_data['error']}[/bold red]")
 
-    console.print("[bold blue]✨ Session finished. Thank you for using DeepSeek Engineer![/bold blue]")
+    console.print("[bold blue]✨ Session finished. Thank you for using Devstral Engineer![/bold blue]")
 
 if __name__ == "__main__":
     main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "deepseek-engineer"
+name = "devstral-engineer"
 version = "0.1.0"
 description = "Add your description here"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -43,7 +43,7 @@ wheels = [
 ]
 
 [[package]]
-name = "deepseek-engineer"
+name = "devstral-engineer"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [


### PR DESCRIPTION
## Summary
- rename project and script to Devstral
- use OpenRouter API with `mistralai/devstral-small:free`
- update documentation for new model and API key
- adjust license ownership

## Testing
- `python3 -m py_compile devstral-eng.py`

------
https://chatgpt.com/codex/tasks/task_e_68424ba2d0988332a119e39cf6ab4e9d