### PR TITLE
Add deep research command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Devstral Engineer v2 is a powerful AI-powered coding assistant that provides an 
 - **Chain of Thought Reasoning**: Visible thought process before providing solutions
 - **Code Analysis & Discussion**: Expert-level insights and optimization suggestions
 - **Intelligent Problem Solving**: Automatic file reading and context understanding
-- **Built-in Web Search**: Fetch DuckDuckGo results on demand with `/search`
+- **Built-in Web Search**: Fetch DuckDuckGo results on demand with `/search` or `/deep-research`
 
 ### 🛠️ **Function Calling Tools**
 The AI can automatically execute these operations when needed:
@@ -85,6 +85,7 @@ For when you want to preload files into conversation context:
 - **`/add path/to/folder`** - Include entire directory (with smart filtering)
 - **`/undo`** - Undo the last file change (`/undo N` for multiple steps)
 - **`/search your query`** - Fetch DuckDuckGo results and add them as context
+- **`/deep-research your query`** - Fetch articles for multi-page research
 
 **Note**: The `/add` command is mainly useful when you want to provide extra context upfront. The AI can read files automatically via function calls whenever needed during the conversation.
 

--- a/ddg_deep.py
+++ b/ddg_deep.py
@@ -1,0 +1,118 @@
+import requests
+from bs4 import BeautifulSoup
+from typing import List, Optional
+import time
+
+MAX_DDG_PAGES = 3
+RESULTS_PER_PAGE = 10
+MAX_ARTICLE_LENGTH = 50000
+SUMMARIZE_THRESHOLD = 10000
+REQUEST_DELAY = 1.0
+
+
+def fetch_ddg_page(query: str, start: int = 0) -> Optional[str]:
+    """Fetch one DuckDuckGo results page as HTML."""
+    url = "https://html.duckduckgo.com/html"
+    data = {"q": query, "kl": "us-en", "kp": "-2", "s": str(start)}
+    headers = {"User-Agent": "Mozilla/5.0 (Python) DevstralDeep/1.0"}
+    try:
+        resp = requests.post(url, data=data, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.text
+    except Exception as e:
+        print(f"[ddg_deep] Error fetching page {start}: {e}")
+        return None
+
+
+def parse_ddg_results(html: str) -> List[str]:
+    """Parse DDG HTML and return result URLs."""
+    soup = BeautifulSoup(html, "html.parser")
+    urls: List[str] = []
+    for div in soup.find_all("div", class_="result"):
+        if len(urls) >= RESULTS_PER_PAGE:
+            break
+        a_tag = div.find("a", class_="result__a")
+        if a_tag and a_tag.get("href"):
+            urls.append(a_tag["href"])
+    return urls
+
+
+def fetch_article_text(url: str) -> str:
+    """Fetch the given URL and try to extract main textual content."""
+    try:
+        resp = requests.get(url, headers={"User-Agent": "Mozilla/5.0 (Python) DevstralDeep/1.0"}, timeout=10)
+        resp.raise_for_status()
+        soup = BeautifulSoup(resp.text, "html.parser")
+        art = soup.find("article")
+        if art:
+            txt = art.get_text("\n", strip=True)
+            return txt[:MAX_ARTICLE_LENGTH]
+        best = ""
+        for d in soup.find_all("div"):
+            t = d.get_text("\n", strip=True)
+            if len(t) > len(best):
+                best = t
+        return best[:MAX_ARTICLE_LENGTH]
+    except Exception:
+        return ""
+
+
+def to_markdown(urls: List[str]) -> str:
+    """Convert URLs to a Markdown document with snippets."""
+    lines = ["### Deep Research Articles", ""]
+    for idx, link in enumerate(urls, start=1):
+        text = fetch_article_text(link)
+        if not text:
+            lines.append(f"#### {idx}. [Failed to fetch {link}]")
+            lines.append("")
+            continue
+        snippet = text[:200].replace("\n", " ")
+        lines.append(f"#### {idx}. [{link}]({link})")
+        lines.append(f"> {snippet}...")
+        lines.append("")
+        lines.append("<details>")
+        lines.append("<summary>Read more</summary>")
+        lines.append("")
+        lines.append(text)
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+        time.sleep(REQUEST_DELAY)
+    return "\n".join(lines)
+
+
+def deep_research(query: str) -> str:
+    """Perform multi-page DuckDuckGo scraping and return Markdown."""
+    collected: List[str] = []
+    for page in range(MAX_DDG_PAGES):
+        start_idx = page * RESULTS_PER_PAGE
+        html = fetch_ddg_page(query, start=start_idx)
+        if not html:
+            break
+        page_urls = parse_ddg_results(html)
+        if not page_urls:
+            break
+        collected.extend(page_urls)
+        soup = BeautifulSoup(html, "html.parser")
+        more = soup.find("a", class_="result--more__btn")
+        if not more:
+            break
+        time.sleep(REQUEST_DELAY)
+
+    unique_urls: List[str] = []
+    seen = set()
+    for u in collected:
+        if u not in seen:
+            seen.add(u)
+            unique_urls.append(u)
+
+    md = to_markdown(unique_urls)
+    if len(md) > SUMMARIZE_THRESHOLD:
+        return f"*Deep research results exceed {SUMMARIZE_THRESHOLD} chars; please summarize below:*\n\n{md}"
+    return md
+
+
+if __name__ == "__main__":
+    q = "python web scraping"
+    result = deep_research(q)
+    print(result[:2000])

--- a/devstral-eng.py
+++ b/devstral-eng.py
@@ -23,6 +23,8 @@ import difflib
 
 # DuckDuckGo helper for on-demand web search
 from ddg_search import ddg_search, ddg_results_to_markdown
+# Deep research helper for multi-page scraping
+from ddg_deep import deep_research
 
 try:
     import tiktoken
@@ -690,6 +692,28 @@ def try_handle_search_command(user_input: str) -> bool:
         })
     return True
 
+
+def try_handle_deep_command(user_input: str) -> bool:
+    """Handle '/deep-research <query>' for multi-page scraping."""
+    prefix = "/deep-research "
+    if not user_input.lower().startswith(prefix):
+        return False
+
+    query_terms = user_input[len(prefix):].strip()
+    if not query_terms:
+        console.print("[bold yellow]⚠ Usage:[/bold yellow] /deep-research <your query>")
+        return True
+
+    console.print(f"[bold blue]🔎 Starting Deep Research for:[/bold blue] '{query_terms}'")
+    try:
+        md_content = deep_research(query_terms)
+        conversation_history.append({"role": "system", "content": md_content})
+        console.print(Panel(md_content, title="Deep Research Results (Markdown)", border_style="magenta"))
+    except Exception as e:
+        console.print(f"[bold red]✗ Deep research failed:[/bold red] {e}")
+        conversation_history.append({"role": "system", "content": f"Error during deep research for '{query_terms}': {e}"})
+    return True
+
 def add_directory_to_conversation(directory_path: str):
     with console.status("[bold bright_blue]🔍 Scanning directory...[/bold bright_blue]") as status:
         excluded_files = {
@@ -1296,6 +1320,7 @@ def main():
   • [bright_cyan]exit[/bright_cyan] or [bright_cyan]quit[/bright_cyan] - End the session
   • [bright_cyan]/help[/bright_cyan] - Show available tools
   • [bright_cyan]/search your query[/bright_cyan] - Inject DuckDuckGo search results
+  • [bright_cyan]/deep-research your query[/bright_cyan] - Fetch articles for in-depth research
   • [bright_cyan]/edit[/bright_cyan] or [bright_cyan]/ask[/bright_cyan] - Switch modes
   • Just ask naturally - the AI will handle file operations automatically!"""
     
@@ -1346,6 +1371,9 @@ def main():
             continue
 
         if try_handle_search_command(user_input):
+            continue
+
+        if try_handle_deep_command(user_input):
             continue
 
         if user_input.lower().startswith("/undo"):


### PR DESCRIPTION
## Summary
- implement ddg_deep helper for multi-page DuckDuckGo scraping and article fetching
- support `/deep-research` command in devstral-eng to collect article content in Markdown
- display command in help instructions
- document new command in README

## Testing
- `pytest -q`
- `python -m py_compile devstral-eng.py ddg_deep.py ddg_search.py`


------
https://chatgpt.com/codex/tasks/task_e_68425f2572508332a6979a1ee4b22bdd