### PR TITLE
Prompt confirmation before diff edits

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -16,6 +16,7 @@ from rich.console import Console
 from rich.table import Table
 from rich.panel import Panel
 from rich.style import Style
+import questionary
 from prompt_toolkit import PromptSession
 from prompt_toolkit.styles import Style as PromptStyle
 import time
@@ -627,6 +628,12 @@ def apply_diff_edit(path: str, original_snippet: str, new_snippet: str):
             lineterm=""
         ))
         console.print(Panel(diff, title=f"Diff for {path}", border_style="green"))
+
+        confirm = questionary.confirm("Apply this diff?", default=False).ask()
+        if not confirm:
+            console.print("[bold yellow]⚠ Diff edit skipped by user[/bold yellow]")
+            return
+
         create_file(path, updated_content)
         console.print(f"[bold blue]✓[/bold blue] Applied diff edit to '[bright_cyan]{path}[/bright_cyan]'")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "requests>=2.32.0",
     "beautifulsoup4>=4.12.3",
     "typer>=0.12.3",
+    "questionary>=2.0.1",
 ]
 
 [project.scripts]

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ pyyaml
 requests
 beautifulsoup4
 typer
+questionary


### PR DESCRIPTION
## Summary
- ask user to confirm diff edits before applying them
- add questionary as a dependency

## Testing
- `pip install questionary`
- `python -m py_compile devstral_eng.py devstral_cli/*.py ddg_search.py ddg_deep.py config.py`


------
https://chatgpt.com/codex/tasks/task_e_684266abff78833286ddb12e7f4269de