### PR TITLE
Add partial file view tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,10 @@ The AI can automatically execute these operations when needed:
 - Batch read multiple files efficiently
 - Formatted output with clear file separators
 
+#### `view(file_path: str, offset: int, limit: int)`
+- Display part of a file starting at `offset` showing up to `limit` lines
+- For very large files a short summary is appended
+
 #### `create_file(file_path: str, content: str)`
 - Create new files or overwrite existing ones
 - Automatic directory creation and safety checks

--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -1,25 +1,35 @@
-from pathlib import Path
 import typer
 from config import Config, CONFIG_FILE
 from .chat import chat
 
 app = typer.Typer(help="Devstral Engineer CLI")
 
+
 @app.callback(invoke_without_command=True)
-def main(ctx: typer.Context,
-         verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
-         debug: bool = typer.Option(False, "--debug", help="Debug output")) -> None:
+def main(
+    ctx: typer.Context,
+    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
+    debug: bool = typer.Option(False, "--debug", help="Debug output"),
+) -> None:
     """Start interactive chat when no subcommand is provided."""
     if ctx.invoked_subcommand is None:
         chat(verbose=verbose, debug=debug)
 
+
 @app.command()
-def setup(api_key: str = typer.Option(..., prompt=True, hide_input=True, help="OpenRouter API key"),
-          model: str = typer.Option("mistralai/devstral-small:free", prompt="Default model", show_default=True)) -> None:
+def setup(
+    api_key: str = typer.Option(
+        ..., prompt=True, hide_input=True, help="OpenRouter API key"
+    ),
+    model: str = typer.Option(
+        "mistralai/devstral-small:free", prompt="Default model", show_default=True
+    ),
+) -> None:
     """Create or update configuration."""
     cfg = Config(api_key=api_key, default_model=model)
     cfg.save()
     typer.echo(f"Configuration written to {CONFIG_FILE}")
+
 
 @app.command("set-default-model")
 def set_default_model(model: str) -> None:


### PR DESCRIPTION
## Summary
- support partial file viewing with a new `view` function
- update available tools in system prompt and docs
- expose `view` through function calling tool list
- clean unused imports and fix linter warnings

## Testing
- `ruff check`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68426953fae08332ab5d81814fa4ce06