### PR TITLE
Implement DDG search caching

### DIFF
--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -1,5 +1,6 @@
 import typer
 from config import Config, CONFIG_FILE
+from ddg_search import clear_ddg_cache
 from .chat import chat
 
 app = typer.Typer(help="Devstral Engineer CLI")
@@ -38,3 +39,10 @@ def set_default_model(model: str) -> None:
     cfg.default_model = model
     cfg.save()
     typer.echo(f"Default model set to {model}")
+
+
+@app.command("clear-cache")
+def clear_cache() -> None:
+    """Remove cached DuckDuckGo search results."""
+    clear_ddg_cache()
+    typer.echo("DuckDuckGo cache cleared.")


### PR DESCRIPTION
## Summary
- cache DDG search results under `~/.cache/devstral-engineer/ddg_cache.json`
- support clearing the cache from the CLI

## Testing
- `python -m py_compile ddg_search.py devstral_cli/__init__.py`
- `python -m devstral_cli --help` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6842ec4eea208332b0bd28637acd4e94