### PR TITLE
Enable automated testing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ main, master ]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pydantic>=2.10.4 pytest
+      - name: Run tests
+        run: pytest -q

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,10 @@
+import os
+from pathlib import Path
+from config import Config
+
+def test_config_roundtrip(tmp_path):
+    cfg = Config(api_key="key", default_model="model")
+    path = tmp_path / "config.yaml"
+    cfg.save(path)
+    loaded = Config.load(path)
+    assert loaded.model_dump() == cfg.model_dump()

--- a/tests/test_ddg_search.py
+++ b/tests/test_ddg_search.py
@@ -1,0 +1,23 @@
+from ddg_search import parse_ddg_html, ddg_results_to_markdown
+
+SAMPLE_HTML = '''
+<div class="result">
+  <a class="result__a" href="http://example.com">Example Domain</a>
+  <a class="result__snippet">Example snippet.</a>
+</div>
+'''
+
+def test_parse_ddg_html():
+    results = parse_ddg_html(SAMPLE_HTML, max_results=1)
+    assert results == [{
+        "title": "Example Domain",
+        "url": "http://example.com",
+        "snippet": "Example snippet."
+    }]
+
+def test_ddg_results_to_markdown():
+    md = ddg_results_to_markdown([
+        {"title": "Example Domain", "url": "http://example.com", "snippet": "Example snippet."}
+    ])
+    assert md.splitlines()[0] == "### DuckDuckGo Search Results"
+    assert "- [Example Domain](http://example.com): Example snippet." in md


### PR DESCRIPTION
## Summary
- add simple unit tests for config and DuckDuckGo helpers
- run tests in GitHub Actions on Python 3.11 and 3.12

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd3efbd88332b9e7b3c1ca04f003