### PR TITLE
Update normalize_path and tests

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -1233,15 +1233,19 @@ def ensure_file_in_context(file_path: str) -> bool:
 
 def normalize_path(path_str: str) -> str:
     """Return a canonical, absolute version of the path with security checks."""
-    path = Path(path_str).resolve()
+    path = Path(path_str)
 
-    # Prevent directory traversal attacks
+    # Validate the raw input *before* resolving
+    if path_str.startswith("~"):
+        raise ValueError(f"Invalid path: {path_str} starts with '~'")
+
     if ".." in path.parts:
         raise ValueError(
             f"Invalid path: {path_str} contains parent directory references"
         )
 
-    return str(path)
+    resolved = (Path.cwd() / path).resolve()
+    return str(resolved)
 
 
 def undo_last_change(num_undos: int = 1):

--- a/tests/test_normalize_path.py
+++ b/tests/test_normalize_path.py
@@ -1,0 +1,44 @@
+from pathlib import Path
+import ast
+import types
+import pytest
+
+# Load only the normalize_path function from devstral_eng.py without importing
+source = Path(__file__).resolve().parents[1] / "devstral_eng.py"
+mod_ast = ast.parse(source.read_text())
+fn_node = next(
+    n for n in mod_ast.body if isinstance(n, ast.FunctionDef) and n.name == "normalize_path"
+)
+module = types.ModuleType("_normalize")
+module.__dict__["Path"] = Path
+exec(
+    compile(ast.Module([fn_node], []), filename=str(source), mode="exec"),
+    module.__dict__,
+)
+normalize_path = module.normalize_path
+
+
+def test_normalize_valid_relative(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    p = "subdir/file.txt"
+    expected = str((tmp_path / p).resolve())
+    assert normalize_path(p) == expected
+
+
+def test_normalize_valid_absolute(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    abs_path = tmp_path / "absfile.txt"
+    expected = str(abs_path.resolve())
+    assert normalize_path(str(abs_path)) == expected
+
+
+def test_reject_parent_directory(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError):
+        normalize_path("../bad")
+
+
+def test_reject_leading_tilde(monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError):
+        normalize_path("~/bad")


### PR DESCRIPTION
## Summary
- validate path before resolving in `normalize_path`
- disallow leading `~` or `..`
- add tests for valid and invalid paths

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd58866c833285f007048ab25b2a