### PR TITLE
Add normalize_path tests

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -1233,13 +1233,20 @@ def ensure_file_in_context(file_path: str) -> bool:
 
 def normalize_path(path_str: str) -> str:
     """Return a canonical, absolute version of the path with security checks."""
-    path = Path(path_str).resolve()
+    raw_path = Path(path_str)
 
-    # Prevent directory traversal attacks
-    if ".." in path.parts:
+    # Prevent directory traversal or home directory references before resolving
+    if ".." in raw_path.parts:
         raise ValueError(
             f"Invalid path: {path_str} contains parent directory references"
         )
+
+    if any(part.startswith("~") for part in raw_path.parts):
+        raise ValueError(
+            f"Invalid path: {path_str} contains home directory references"
+        )
+
+    path = raw_path.resolve()
 
     return str(path)
 

--- a/tests/test_normalize_path.py
+++ b/tests/test_normalize_path.py
@@ -1,0 +1,33 @@
+import sys
+import os
+from pathlib import Path
+import pytest
+
+# Ensure the project root is on sys.path for module imports
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Ensure OpenAI client doesn't error out during module import
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+
+from devstral_eng import normalize_path
+
+
+def test_normalize_path_returns_absolute(tmp_path):
+    file = tmp_path / "example.txt"
+    file.write_text("hi")
+    normalized = normalize_path(str(file))
+    assert Path(normalized).is_absolute()
+    assert Path(normalized) == file.resolve()
+
+
+def test_normalize_path_rejects_parent_refs():
+    with pytest.raises(ValueError):
+        normalize_path("../outside.txt")
+
+
+def test_normalize_path_rejects_home_refs():
+    with pytest.raises(ValueError):
+        normalize_path("~/secrets.txt")


### PR DESCRIPTION
## Summary
- add tests for normalize_path
- tighten normalize_path checks for `..` and `~`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842fd6122888332a714c98455df5df6