### PR TITLE
Remove unused imports in test_config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,3 @@
-import os
-from pathlib import Path
 from config import Config
 
 def test_config_roundtrip(tmp_path):


### PR DESCRIPTION
## Summary
- clean up `tests/test_config.py` by deleting unused `os` and `Path` imports

## Testing
- `ruff check tests/test_config.py`

------
https://chatgpt.com/codex/tasks/task_e_684304e6ca808332ba465a2ff0981a7d