### PR TITLE
Run ruff as part of CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,8 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pydantic>=2.10.4 pytest
+          pip install pydantic>=2.10.4 pytest ruff
+      - name: Run Ruff
+        run: ruff check .
       - name: Run tests
         run: pytest -q


### PR DESCRIPTION
## Summary
- run ruff lint in GitHub Actions
- install `ruff` alongside other dependencies

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843067ac4cc8332b978b34c188b9ea9