### PR TITLE
Add async ddg_deep tests

### DIFF
--- a/tests/test_ddg_deep.py
+++ b/tests/test_ddg_deep.py
@@ -31,3 +31,51 @@ def test_parse_ddg_results_respects_limit():
     assert urls[0] == "http://site0.com"
     assert urls[-1] == f"http://site{RESULTS_PER_PAGE - 1}.com"
 
+
+@pytest.mark.asyncio
+async def test_to_markdown_formats(monkeypatch):
+    async def fake_fetch(url):
+        return f"Content from {url}"
+    monkeypatch.setattr("ddg_deep.fetch_article_text_async", fake_fetch)
+    async def noop(_):
+        pass
+    monkeypatch.setattr("ddg_deep.asyncio.sleep", noop)
+    from ddg_deep import to_markdown
+    md = await to_markdown(["http://a.com", "http://b.com"])
+    assert md.startswith("### Deep Research Articles")
+    assert "#### 1. [http://a.com](http://a.com)" in md
+    assert "#### 2. [http://b.com](http://b.com)" in md
+    assert "Content from http://a.com" in md
+    assert "Content from http://b.com" in md
+
+
+@pytest.mark.asyncio
+async def test_deep_research_aggregates_pages(monkeypatch):
+    PAGE1 = '''
+    <div class="result"><a class="result__a" href="http://a.com">A</a></div>
+    <div class="result"><a class="result__a" href="http://b.com">B</a></div>
+    <a class="result--more__btn" href="#">More</a>
+    '''
+    PAGE2 = '''
+    <div class="result"><a class="result__a" href="http://b.com">B</a></div>
+    <div class="result"><a class="result__a" href="http://c.com">C</a></div>
+    '''
+    async def fake_page(query, start=0):
+        if start == 0:
+            return PAGE1
+        elif start == RESULTS_PER_PAGE:
+            return PAGE2
+        return None
+    monkeypatch.setattr("ddg_deep.fetch_ddg_page", fake_page)
+    async def fake_article(url):
+        return f"Article for {url}"
+    monkeypatch.setattr("ddg_deep.fetch_article_text_async", fake_article)
+    async def noop(_):
+        pass
+    monkeypatch.setattr("ddg_deep.asyncio.sleep", noop)
+    from ddg_deep import deep_research
+    md = await deep_research("test")
+    assert md.count("<details>") == 3
+    assert "http://a.com" in md
+    assert "http://b.com" in md
+    assert "http://c.com" in md


### PR DESCRIPTION
## Summary
- extend `tests/test_ddg_deep.py` with async tests for `to_markdown` and `deep_research`
- mock aiohttp network calls and time delays

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68430d36766c8332ab4cc14960822607