### PR TITLE
Add basic code index engine

### DIFF
--- a/code_index_engine/__init__.py
+++ b/code_index_engine/__init__.py
@@ -1,0 +1,5 @@
+from .scanner import WorkspaceScanner
+from .watcher import WorkspaceWatcher
+from .embeddings import embed_text
+
+__all__ = ["WorkspaceScanner", "WorkspaceWatcher", "embed_text"]

--- a/code_index_engine/api.py
+++ b/code_index_engine/api.py
@@ -1,0 +1,44 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+from pathlib import Path
+from .scanner import WorkspaceScanner
+from .watcher import WorkspaceWatcher
+
+app = FastAPI()
+
+scanner: WorkspaceScanner | None = None
+watcher: WorkspaceWatcher | None = None
+
+class StartRequest(BaseModel):
+    path: str
+
+class SearchRequest(BaseModel):
+    query: str
+    top_k: int = 5
+
+@app.post('/start')
+def start(req: StartRequest):
+    global scanner, watcher
+    root = Path(req.path)
+    if not root.exists():
+        raise HTTPException(status_code=404, detail='Path not found')
+    scanner = WorkspaceScanner(root)
+    scanner.scan()
+    watcher = WorkspaceWatcher(scanner)
+    watcher.start()
+    return {'status':'started'}
+
+@app.post('/stop')
+def stop():
+    global watcher
+    if watcher:
+        watcher.stop()
+        watcher = None
+    return {'status':'stopped'}
+
+@app.post('/search')
+def search(req: SearchRequest):
+    if not scanner:
+        raise HTTPException(status_code=400, detail='not started')
+    blocks = scanner.search(req.query, req.top_k)
+    return [{'path':str(b.path), 'content':b.content[:200]} for b in blocks]

--- a/code_index_engine/embeddings.py
+++ b/code_index_engine/embeddings.py
@@ -1,0 +1,13 @@
+import hashlib
+import numpy as np
+from typing import List
+
+def embed_text(text: str, dim: int = 32) -> List[float]:
+    """Generate a deterministic embedding vector from text using SHA256."""
+    digest = hashlib.sha256(text.encode("utf-8")).digest()
+    # Repeat digest to cover dim*4 bytes (float32)
+    while len(digest) < dim * 4:
+        digest += hashlib.sha256(digest).digest()
+    floats = np.frombuffer(digest[: dim * 4], dtype=np.uint32)
+    normalized = floats / floats.max()
+    return normalized.astype(float).tolist()

--- a/code_index_engine/scanner.py
+++ b/code_index_engine/scanner.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+from typing import List, Dict
+import pathspec
+from .embeddings import embed_text
+
+SUPPORTED_EXTENSIONS = {
+    '.py', '.js', '.ts', '.rs', '.go', '.java', '.cpp', '.c', '.h', '.cs', '.rb', '.php'
+}
+
+class IndexedBlock:
+    def __init__(self, path: Path, content: str, embedding: List[float]):
+        self.path = path
+        self.content = content
+        self.embedding = embedding
+
+class WorkspaceScanner:
+    def __init__(self, root: Path):
+        self.root = root
+        self.index: Dict[Path, IndexedBlock] = {}
+        self._load_gitignore()
+
+    def _load_gitignore(self):
+        gitignore = self.root / '.gitignore'
+        if gitignore.exists():
+            patterns = gitignore.read_text().splitlines()
+            self.spec = pathspec.PathSpec.from_lines('gitwildmatch', patterns)
+        else:
+            self.spec = pathspec.PathSpec.from_lines('gitwildmatch', [])
+
+    def scan(self):
+        for file in self.root.rglob('*'):
+            if file.is_file() and file.suffix in SUPPORTED_EXTENSIONS:
+                rel = file.relative_to(self.root)
+                if self.spec.match_file(str(rel)):
+                    continue
+                text = file.read_text(errors='ignore')
+                embedding = embed_text(text)
+                self.index[file] = IndexedBlock(file, text, embedding)
+
+    def search(self, query: str, top_k: int = 5) -> List[IndexedBlock]:
+        from numpy import dot
+        from numpy.linalg import norm
+        q = embed_text(query)
+        results = []
+        for block in self.index.values():
+            v = block.embedding
+            score = dot(q, v) / (norm(q) * norm(v) + 1e-6)
+            results.append((score, block))
+        results.sort(key=lambda x: x[0], reverse=True)
+        return [b for _, b in results[:top_k]]

--- a/code_index_engine/watcher.py
+++ b/code_index_engine/watcher.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+from watchdog.observers import Observer
+from watchdog.events import FileSystemEventHandler
+from .scanner import WorkspaceScanner, SUPPORTED_EXTENSIONS, IndexedBlock
+
+class _Handler(FileSystemEventHandler):
+    def __init__(self, scanner: WorkspaceScanner):
+        self.scanner = scanner
+
+    def on_created(self, event):
+        self._handle(event.src_path)
+
+    def on_modified(self, event):
+        self._handle(event.src_path)
+
+    def on_deleted(self, event):
+        path = Path(event.src_path)
+        if path in self.scanner.index:
+            del self.scanner.index[path]
+
+    def _handle(self, path_str: str):
+        path = Path(path_str)
+        if path.suffix in SUPPORTED_EXTENSIONS and path.is_file():
+            rel = path.relative_to(self.scanner.root)
+            if self.scanner.spec.match_file(str(rel)):
+                return
+            text = path.read_text(errors='ignore')
+            embedding = self.scanner.index[path].embedding if path in self.scanner.index else None
+            if embedding is None or self.scanner.index[path].content != text:
+                from .embeddings import embed_text
+                self.scanner.index[path] = IndexedBlock(path, text, embed_text(text))
+
+class WorkspaceWatcher:
+    def __init__(self, scanner: WorkspaceScanner):
+        self.scanner = scanner
+        self.observer = Observer()
+        self.handler = _Handler(scanner)
+
+    def start(self):
+        self.observer.schedule(self.handler, str(self.scanner.root), recursive=True)
+        self.observer.start()
+
+    def stop(self):
+        self.observer.stop()
+        self.observer.join()

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,9 @@ aiohttp>=3.9.5
 beautifulsoup4>=4.12.3
 typer>=0.12.3
 questionary>=2.0.1
+
+pathspec>=0.12.1
+watchdog>=3.0.0
+fastapi>=0.110.0
+uvicorn>=0.29.0
+numpy>=1.26.0

--- a/tests/test_code_index_engine.py
+++ b/tests/test_code_index_engine.py
@@ -1,0 +1,32 @@
+import time
+from pathlib import Path
+from code_index_engine.scanner import WorkspaceScanner
+from code_index_engine.watcher import WorkspaceWatcher
+
+
+def test_scanner_respects_gitignore(tmp_path):
+    (tmp_path / '.gitignore').write_text('ignored.py\n')
+    good = tmp_path / 'good.py'
+    ignored = tmp_path / 'ignored.py'
+    good.write_text('print("ok")')
+    ignored.write_text('print("no")')
+    scanner = WorkspaceScanner(tmp_path)
+    scanner.scan()
+    assert good in scanner.index
+    assert ignored not in scanner.index
+
+
+def test_watcher_updates_index(tmp_path):
+    f = tmp_path / 'file.py'
+    f.write_text('a=1')
+    scanner = WorkspaceScanner(tmp_path)
+    scanner.scan()
+    watcher = WorkspaceWatcher(scanner)
+    watcher.start()
+    try:
+        f.write_text('a=2')
+        time.sleep(0.5)
+        assert scanner.index[f].content == 'a=2'
+    finally:
+        watcher.stop()
+


### PR DESCRIPTION
## Summary
- add code_index_engine package with simple workspace scanner and watcher
- expose REST API to start/stop indexing and search
- create deterministic embedding utility
- include unit tests for scanner and watcher
- update requirements with new dependencies

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68430ffc95fc8332bf2e2111a784061d