### PR TITLE
Add CLI history commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ You> Now review this codebase structure
 - **File content preservation** across conversation history
 - **Tool message integration** for complete operation tracking
 - **Persistent history** stored in `~/.config/devstral-engineer/conversation_history.json`
+- **View history** with `devstral history` or clear it using `devstral clear-history`
 
 ### **Batch Operations**
 ```
@@ -314,6 +315,12 @@ uv run -m devstral_cli
 or
 ```bash
 devstral
+```
+
+### History Commands
+```bash
+devstral history        # show saved conversation
+devstral clear-history  # remove saved conversation
 ```
 
 ### Debug Profiling

--- a/conversation_store.py
+++ b/conversation_store.py
@@ -24,3 +24,17 @@ def save_history(history: List[Dict[str, Any]]) -> None:
     HISTORY_FILE.parent.mkdir(parents=True, exist_ok=True)
     with HISTORY_FILE.open("w", encoding="utf-8") as f:
         json.dump(history, f, ensure_ascii=False, indent=2)
+
+
+def display_history() -> str:
+    """Return the stored conversation history formatted as JSON."""
+    history = load_history()
+    if not history:
+        return "No conversation history found."
+    return json.dumps(history, ensure_ascii=False, indent=2)
+
+
+def clear_history() -> None:
+    """Remove the stored conversation history file."""
+    if HISTORY_FILE.exists():
+        HISTORY_FILE.unlink()

--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -1,10 +1,14 @@
 import typer
 from config import Config, CONFIG_FILE
 from ddg_search import clear_ddg_cache
+from conversation_store import display_history, clear_history
 from .chat import chat
 
 app = typer.Typer(
-    help="Devstral Engineer CLI - conversation history is saved between sessions"
+    help=(
+        "Devstral Engineer CLI - conversation history is saved between sessions."
+        " Use the 'history' command to view or 'clear-history' to delete it."
+    )
 )
 
 
@@ -48,3 +52,16 @@ def clear_cache() -> None:
     """Remove cached DuckDuckGo search results."""
     clear_ddg_cache()
     typer.echo("DuckDuckGo cache cleared.")
+
+
+@app.command("history")
+def view_history() -> None:
+    """Display the stored conversation history."""
+    typer.echo(display_history())
+
+
+@app.command("clear-history")
+def clear_history_cmd() -> None:
+    """Delete the stored conversation history."""
+    clear_history()
+    typer.echo("Conversation history cleared.")

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -1,4 +1,10 @@
-from conversation_store import load_history, save_history, HISTORY_FILE
+from conversation_store import (
+    load_history,
+    save_history,
+    display_history,
+    clear_history,
+    HISTORY_FILE,
+)
 
 
 def test_load_missing(tmp_path, monkeypatch):
@@ -14,3 +20,14 @@ def test_roundtrip(tmp_path, monkeypatch):
     save_history(sample)
     assert file.exists()
     assert load_history() == sample
+
+
+def test_display_and_clear(tmp_path, monkeypatch):
+    file = tmp_path / "hist.json"
+    monkeypatch.setattr("conversation_store.HISTORY_FILE", file)
+    sample = [{"role": "assistant", "content": "hello"}]
+    save_history(sample)
+    text = display_history()
+    assert "assistant" in text
+    clear_history()
+    assert not file.exists()


### PR DESCRIPTION
## Summary
- add `display_history` and `clear_history` helpers
- expose new `history` and `clear-history` CLI subcommands
- document history commands in README
- test history display and clearing

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6843120789088332bdea34bd13f6ee7b