### PR TITLE
Add search_code tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,8 @@ The AI can automatically execute these operations when needed:
 - Trigger project build systems
 #### `manage_dependency(action: str, package: str)`
 - Install or uninstall dependencies via pip
+#### `search_code(query: str, directory_prefix: str)`
+- Search indexed code snippets optionally filtered by directory
 
 ### 📁 **File Operations**
 
@@ -95,6 +97,7 @@ For when you want to preload files into conversation context:
 - **`/undo`** - Undo the last file change (`/undo N` for multiple steps)
 - **`/search your query`** - Fetch DuckDuckGo results and add them as context
 - **`/deep-research your query`** - Fetch articles for multi-page research
+- **`/code-search your query`** - Search your indexed workspace
 
 **Note**: The `/add` command is mainly useful when you want to provide extra context upfront. The AI can read files automatically via function calls whenever needed during the conversation.
 
@@ -215,6 +218,16 @@ You> Now review this codebase structure
 🤖 Assistant> I've reviewed your codebase and found several areas for improvement:
 
 1. **Error Handling**: The utils.py file could benefit from more robust error handling...
+```
+
+#### **Indexed Code Search**
+```
+You> /code-search foo
+
+src/foo.py
+```python
+def foo():
+    pass
 ```
 
 ## Technical Details

--- a/tests/test_search_code.py
+++ b/tests/test_search_code.py
@@ -1,0 +1,55 @@
+import asyncio
+import time
+import os
+
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+import devstral_eng
+
+async def wait_for_status(client, timeout=10.0):
+    start = time.time()
+    while time.time() - start < timeout:
+        try:
+            await client.status()
+            return
+        except Exception:
+            await asyncio.sleep(0.2)
+    raise RuntimeError("engine did not start")
+
+
+def test_search_code_returns_matches(tmp_path):
+    sample = tmp_path / "match.py"
+    sample.write_text("def foo(): pass")
+    port = 8600
+    devstral_eng.launch_engine(port)
+    asyncio.run(wait_for_status(devstral_eng.index_client))
+    asyncio.run(devstral_eng.index_client.start(str(tmp_path)))
+    try:
+        output = asyncio.run(devstral_eng.search_code("foo"))
+        assert "match.py" in output
+        assert "foo" in output
+    finally:
+        asyncio.run(devstral_eng.index_client.stop())
+        devstral_eng.engine_proc.terminate()
+        devstral_eng.engine_proc.wait(timeout=5)
+
+
+def test_search_code_directory_filter(tmp_path):
+    d = tmp_path / "sub"
+    d.mkdir()
+    f1 = d / "one.py"
+    f2 = tmp_path / "two.py"
+    f1.write_text("def bar(): pass")
+    f2.write_text("def bar(): pass")
+    port = 8601
+    devstral_eng.launch_engine(port)
+    asyncio.run(wait_for_status(devstral_eng.index_client))
+    asyncio.run(devstral_eng.index_client.start(str(tmp_path)))
+    try:
+        output = asyncio.run(devstral_eng.search_code("bar", directory_prefix=str(d)))
+        assert str(f1) in output
+        assert str(f2) not in output
+    finally:
+        asyncio.run(devstral_eng.index_client.stop())
+        devstral_eng.engine_proc.terminate()
+        devstral_eng.engine_proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- add `search_code` function tool and dispatch
- implement code search using IndexClient
- document `/code-search` command and search_code tool
- provide example usage in README
- test code search handler and filtering

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68431a70a38483329fad8ee6dd75a127