### PR TITLE
Add pytest optional deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,6 +332,7 @@ git clone <repository-url>
 cd devstral-engineer
 uv venv
 uv sync
+uv pip install pytest pytest-asyncio  # install test requirements
 ```
 
 ### **Run**

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,3 +21,9 @@ dependencies = [
 
 [project.scripts]
 devstral = "devstral_cli:app"
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.4.0",
+    "pytest-asyncio>=0.23.6",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,5 @@ watchdog>=3.0.0
 fastapi>=0.110.0
 uvicorn>=0.29.0
 numpy>=1.26.0
+pytest>=8.4.0
+pytest-asyncio>=0.23.6


### PR DESCRIPTION
## Summary
- include pytest and pytest-asyncio in requirements
- add optional dev dependencies section in `pyproject.toml`
- document install of pytest in development setup

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'yaml')*

------
https://chatgpt.com/codex/tasks/task_e_6843207aac508332a2bc61ae49323a16