### PR TITLE
Ensure runtime deps for tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,11 @@ dependencies = [
     "beautifulsoup4>=4.12.3",
     "typer>=0.12.3",
     "questionary>=2.0.1",
+    "numpy>=1.26.0",
+    "pathspec>=0.12.1",
+    "watchdog>=3.0.0",
+    "fastapi>=0.110.0",
+    "uvicorn>=0.29.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary
- install missing runtime packages for numpy-based embedding and the FastAPI server

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6843246ff49c8332a0ecb481bec4cc8c