### PR TITLE
Ensure normalized paths don't escape workspace

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -1406,7 +1406,15 @@ def normalize_path(path_str: str) -> str:
         )
 
     # Now resolve against cwd (and return an absolute path)
-    return str(path.resolve())
+    resolved = path.resolve()
+    base_dir = Path.cwd().resolve()
+    try:
+        resolved.relative_to(base_dir)
+    except ValueError:
+        raise ValueError(
+            f"Invalid path: {resolved!r} escapes the workspace root {base_dir!r}"
+        )
+    return str(resolved)
 
 
 def undo_last_change(num_undos: int = 1):

--- a/tests/test_secure_paths.py
+++ b/tests/test_secure_paths.py
@@ -24,3 +24,23 @@ def test_create_directory_rejects_tilde(monkeypatch, tmp_path):
     monkeypatch.chdir(tmp_path)
     result = create_directory("~/bad")
     assert result.startswith("Error")
+
+
+def test_create_file_symlink_escape(monkeypatch, tmp_path, tmp_path_factory):
+    outside = tmp_path_factory.mktemp("outside")
+    target = outside / "secret.txt"
+    target.write_text("secret")
+    link = tmp_path / "link.txt"
+    link.symlink_to(target)
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(ValueError):
+        create_file("link.txt", "data")
+
+
+def test_create_directory_symlink_escape(monkeypatch, tmp_path, tmp_path_factory):
+    outside = tmp_path_factory.mktemp("outside_dir")
+    link = tmp_path / "linkdir"
+    link.symlink_to(outside, target_is_directory=True)
+    monkeypatch.chdir(tmp_path)
+    result = create_directory("linkdir/sub")
+    assert result.startswith("Error")


### PR DESCRIPTION
## Summary
- validate that paths stay under `Path.cwd()` when normalizing
- add tests for symlink escapes

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for optional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6843493751b483329d47a095368646db