### PR TITLE
Expose engine output with debug flag

### DIFF
--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -15,8 +15,17 @@ app = typer.Typer(
 @app.callback(invoke_without_command=True)
 def main(
     ctx: typer.Context,
-    verbose: bool = typer.Option(False, "--verbose", "-v", help="Verbose output"),
-    debug: bool = typer.Option(False, "--debug", help="Debug output with profiling"),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Verbose output (show engine logs)",
+    ),
+    debug: bool = typer.Option(
+        False,
+        "--debug",
+        help="Debug output with profiling and engine logs",
+    ),
 ) -> None:
     """Start interactive chat when no subcommand is provided."""
     if ctx.invoked_subcommand is None:

--- a/tests/test_engine_recovery.py
+++ b/tests/test_engine_recovery.py
@@ -21,7 +21,7 @@ async def wait_for_status(client, timeout=10.0):
 
 def test_engine_restarts_on_crash(tmp_path):
     port = 9000 + int(time.time()) % 1000
-    devstral_eng.launch_engine(port)
+    devstral_eng.launch_engine(port, debug=False)
     asyncio.run(wait_for_status(devstral_eng.index_client))
     assert devstral_eng.engine_proc.poll() is None
 

--- a/tests/test_search_code.py
+++ b/tests/test_search_code.py
@@ -22,7 +22,7 @@ def test_search_code_returns_matches(tmp_path):
     sample = tmp_path / "match.py"
     sample.write_text("def foo(): pass")
     port = 8600
-    devstral_eng.launch_engine(port)
+    devstral_eng.launch_engine(port, debug=False)
     asyncio.run(wait_for_status(devstral_eng.index_client))
     asyncio.run(devstral_eng.index_client.start(str(tmp_path)))
     try:
@@ -43,7 +43,7 @@ def test_search_code_directory_filter(tmp_path):
     f1.write_text("def bar(): pass")
     f2.write_text("def bar(): pass")
     port = 8601
-    devstral_eng.launch_engine(port)
+    devstral_eng.launch_engine(port, debug=False)
     asyncio.run(wait_for_status(devstral_eng.index_client))
     asyncio.run(devstral_eng.index_client.start(str(tmp_path)))
     try:


### PR DESCRIPTION
## Summary
- show indexing engine logs when debug or verbose flag is used
- propagate CLI options to launch_engine
- adjust tests for new signature

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684361ae844c833298276f9894da70c0