### PR TITLE
Fix stop handler and add status assertions

### DIFF
--- a/code_index_engine/api.py
+++ b/code_index_engine/api.py
@@ -34,10 +34,11 @@ def start(req: StartRequest):
 
 @app.post("/stop")
 def stop():
-    global watcher
+    global scanner, watcher
     if watcher:
         watcher.stop()
         watcher = None
+    scanner = None
     return {"status": "stopped"}
 
 

--- a/tests/test_engine_recovery.py
+++ b/tests/test_engine_recovery.py
@@ -40,5 +40,7 @@ def test_engine_restarts_on_crash(tmp_path):
         devstral_eng.status_stop_event.set()
         t.join(timeout=5)
         asyncio.run(devstral_eng.index_client.stop())
+        status = asyncio.run(devstral_eng.index_client.status())
+        assert status["status"] == "not_started"
         devstral_eng.engine_proc.terminate()
         devstral_eng.engine_proc.wait(timeout=5)

--- a/tests/test_index_engine_process.py
+++ b/tests/test_index_engine_process.py
@@ -41,5 +41,7 @@ def test_engine_process_starts_and_searches(tmp_path):
         assert "sample.py" in results[0]["path"]
     finally:
         asyncio.run(client.stop())
+        status = asyncio.run(client.status())
+        assert status["status"] == "not_started"
         proc.terminate()
         proc.wait(timeout=10)

--- a/tests/test_search_code.py
+++ b/tests/test_search_code.py
@@ -31,6 +31,8 @@ def test_search_code_returns_matches(tmp_path):
         assert "foo" in output
     finally:
         asyncio.run(devstral_eng.index_client.stop())
+        status = asyncio.run(devstral_eng.index_client.status())
+        assert status["status"] == "not_started"
         devstral_eng.engine_proc.terminate()
         devstral_eng.engine_proc.wait(timeout=5)
 
@@ -52,5 +54,7 @@ def test_search_code_directory_filter(tmp_path):
         assert str(f2) not in output
     finally:
         asyncio.run(devstral_eng.index_client.stop())
+        status = asyncio.run(devstral_eng.index_client.status())
+        assert status["status"] == "not_started"
         devstral_eng.engine_proc.terminate()
         devstral_eng.engine_proc.wait(timeout=5)


### PR DESCRIPTION
## Summary
- reset `scanner` in code index engine `/stop` endpoint
- check index server status after stopping in engine tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437d41222083329037f48a69ae125f