### PR TITLE
Fix ddg cache encoding

### DIFF
--- a/ddg_search.py
+++ b/ddg_search.py
@@ -15,7 +15,7 @@ CACHE_TTL_SECONDS = 24 * 60 * 60  # 24 hours
 def _load_cache() -> Dict[str, Dict[str, object]]:
     if CACHE_FILE.exists():
         try:
-            with CACHE_FILE.open("r") as f:
+            with CACHE_FILE.open("r", encoding="utf-8") as f:
                 return json.load(f)
         except Exception:
             return {}
@@ -24,7 +24,7 @@ def _load_cache() -> Dict[str, Dict[str, object]]:
 
 def _save_cache(cache: Dict[str, Dict[str, object]]) -> None:
     CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    with CACHE_FILE.open("w") as f:
+    with CACHE_FILE.open("w", encoding="utf-8") as f:
         json.dump(cache, f)
 
 

--- a/tests/test_ddg_search.py
+++ b/tests/test_ddg_search.py
@@ -1,4 +1,9 @@
-from ddg_search import parse_ddg_html, ddg_results_to_markdown
+from ddg_search import (
+    parse_ddg_html,
+    ddg_results_to_markdown,
+    _save_cache,
+    _load_cache,
+)
 
 SAMPLE_HTML = """
 <div class="result">
@@ -31,3 +36,25 @@ def test_ddg_results_to_markdown():
     )
     assert md.splitlines()[0] == "### DuckDuckGo Search Results"
     assert "- [Example Domain](http://example.com): Example snippet." in md
+
+
+def test_cache_roundtrip_with_utf8(tmp_path, monkeypatch):
+    file = tmp_path / "cache.json"
+    monkeypatch.setattr("ddg_search.CACHE_DIR", tmp_path)
+    monkeypatch.setattr("ddg_search.CACHE_FILE", file)
+    data = {
+        "ключ": {
+            "timestamp": 1,
+            "results": [
+                {
+                    "title": "Пример",
+                    "url": "http://example.com",
+                    "snippet": "Описание",
+                }
+            ],
+        }
+    }
+    _save_cache(data)
+    assert file.exists()
+    loaded = _load_cache()
+    assert loaded == data


### PR DESCRIPTION
## Summary
- store and load ddg cache using UTF-8
- test cache uses proper encoding

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68437ed594808332a8182ac7ca0c8196