### PR TITLE
Add clear endpoint for index engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,12 @@ devstral history        # show saved conversation
 devstral clear-history  # remove saved conversation
 ```
 
+### Index Engine Commands
+```bash
+devstral index-status   # check if the indexing engine is running
+devstral index-clear    # release the current code index
+```
+
 ### Debug Profiling
 Run with `--debug` to see timing information for context management:
 ```bash

--- a/code_index_engine/api.py
+++ b/code_index_engine/api.py
@@ -42,6 +42,17 @@ def stop():
     return {"status": "stopped"}
 
 
+@app.post("/clear")
+def clear():
+    """Release the current index without shutting down the server."""
+    global scanner, watcher
+    if watcher:
+        watcher.stop()
+    scanner = None
+    watcher = None
+    return {"status": "cleared"}
+
+
 @app.post("/search")
 def search(req: SearchRequest):
     if not scanner:

--- a/code_index_engine/client.py
+++ b/code_index_engine/client.py
@@ -22,6 +22,12 @@ class IndexClient:
                 resp.raise_for_status()
                 return await resp.json()
 
+    async def clear(self) -> Any:
+        async with aiohttp.ClientSession() as session:
+            async with session.post(f"{self.base_url}/clear") as resp:
+                resp.raise_for_status()
+                return await resp.json()
+
     async def search(self, query: str, top_k: int = 5) -> List[dict]:
         async with aiohttp.ClientSession() as session:
             async with session.post(

--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -105,3 +105,18 @@ def index_status() -> None:
 
     res = asyncio.run(_run())
     typer.echo(res.get("status", "unknown"))
+
+
+@app.command("index-clear")
+def index_clear() -> None:
+    """Release the current code index."""
+    from code_index_engine.client import IndexClient
+    import asyncio
+
+    client = IndexClient()
+
+    async def _run():
+        return await client.clear()
+
+    res = asyncio.run(_run())
+    typer.echo(res.get("status", "unknown"))


### PR DESCRIPTION
## Summary
- add `/clear` endpoint to release scanner and watcher
- expose `clear()` in the index client
- provide CLI command `index-clear`
- document new command in README

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438031bbdc8332aa890637397dd384