### PR TITLE
Fix binary file detection for UTF‑16 text

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -1366,10 +1366,13 @@ def is_binary_file(file_path: str, peek_size: int = 1024) -> bool:
     try:
         with open(file_path, "rb") as f:
             chunk = f.read(peek_size)
-        # If there is a null byte in the sample, treat it as binary
-        if b"\0" in chunk:
-            return True
-        return False
+
+        # Attempt UTF-8 decoding first
+        if chunk.decode("utf-8", errors="ignore").strip():
+            return False
+
+        # Fallback to null byte detection
+        return b"\0" in chunk
     except Exception:
         # If we fail to read, just treat it as binary to be safe
         return True

--- a/tests/test_is_binary_file.py
+++ b/tests/test_is_binary_file.py
@@ -1,0 +1,10 @@
+import os
+os.environ.setdefault("OPENAI_API_KEY", "test")
+
+from devstral_eng import is_binary_file
+
+
+def test_utf16_not_binary(tmp_path):
+    path = tmp_path / "utf16.txt"
+    path.write_text("hello", encoding="utf-16")
+    assert not is_binary_file(str(path))


### PR DESCRIPTION
## Summary
- improve `is_binary_file` to try UTF‑8 decoding before checking for null bytes
- add regression test for UTF‑16 encoded files

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684387afb79483328e0707a1cba72e46