### PR TITLE
Conditional index engine startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,9 @@ For when you want to preload files into conversation context:
     ```
 
    **Configuration options**:
-   - `indexing_enabled`: enable the local code indexing engine
+   - `indexing_enabled`: enable the local code indexing engine. When set to
+     `true`, the indexing engine is launched automatically on startup; when
+     `false`, code indexing and search are skipped.
    - `index_engine_path`: path to the index engine executable
    - `qdrant_url` / `qdrant_api_key`: connection settings for your Qdrant instance
    - `embedding`: settings for the embedding provider used by the engine
@@ -354,6 +356,8 @@ devstral clear-history  # remove saved conversation
 ```
 
 ### Index Engine Commands
+The code indexing engine is only started when `indexing_enabled` is `true` in
+your configuration.
 ```bash
 devstral index-status   # check if the indexing engine is running
 devstral index-clear    # release the current code index

--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -155,12 +155,8 @@ prompt_session = PromptSession(
 # 1. Configure OpenAI client and load environment variables
 # --------------------------------------------------------------------------------
 load_dotenv()  # Load environment variables from .env file
-cfg = Config.load()
-client = AsyncOpenAI(
-    base_url="https://openrouter.ai/api/v1",
-    api_key=cfg.api_key,
-)
-DEFAULT_MODEL = cfg.default_model
+client: AsyncOpenAI | None = None
+DEFAULT_MODEL = "mistralai/devstral-small:free"
 
 
 # --------------------------------------------------------------------------------
@@ -1976,9 +1972,18 @@ async def stream_openai_response(user_message: str):
 
 async def main():
 
-    # Launch indexing engine subprocess
-    launch_engine(ENGINE_PORT, debug=VERBOSE or DEBUG)
-    start_status_thread()
+    global client, DEFAULT_MODEL
+    config = Config.load()
+    client = AsyncOpenAI(
+        base_url="https://openrouter.ai/api/v1",
+        api_key=config.api_key,
+    )
+    DEFAULT_MODEL = config.default_model
+
+    # Launch indexing engine subprocess only when enabled
+    if config.indexing_enabled:
+        launch_engine(ENGINE_PORT, debug=VERBOSE or DEBUG)
+        start_status_thread()
 
     # Create a beautiful gradient-style welcome panel
     welcome_text = """[bold bright_blue]🐋 Devstral Engineer[/bold bright_blue] [bright_cyan]with Function Calling[/bright_cyan]


### PR DESCRIPTION
## Summary
- load OpenAI configuration inside `main`
- only start the index engine when `indexing_enabled` is true
- document the new behaviour in the README

## Testing
- `pip install -q pytest pytest-asyncio`
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68438ab0233c8332b5fb06f8aaa1e2bd