### PR TITLE
Fix path handling in watcher

### DIFF
--- a/code_index_engine/watcher.py
+++ b/code_index_engine/watcher.py
@@ -9,22 +9,22 @@ class _Handler(FileSystemEventHandler):
         self.scanner = scanner
 
     def on_created(self, event):
-        self._handle(event.src_path)
+        self._handle(str(event.src_path))
 
     def on_modified(self, event):
-        self._handle(event.src_path)
+        self._handle(str(event.src_path))
 
     def on_deleted(self, event):
-        path = Path(event.src_path)
+        path = Path(str(event.src_path))
         if path in self.scanner.index:
             del self.scanner.index[path]
 
     def on_moved(self, event):
-        src = Path(event.src_path)
-        dest = Path(event.dest_path)
+        src = Path(str(event.src_path))
+        _dest = Path(str(event.dest_path))
         if src in self.scanner.index:
             del self.scanner.index[src]
-        self._handle(dest)
+        self._handle(str(event.dest_path))
 
     def _handle(self, path_str: str):
         path = Path(path_str)

--- a/config.py
+++ b/config.py
@@ -16,6 +16,12 @@ class EmbeddingConfig(BaseModel):
     model: Optional[str] = None
     api_key: Optional[str] = None
 
+    # Provide compatibility with pydantic v1
+    def model_dump(self, *args, **kwargs):  # type: ignore[override]
+        if hasattr(BaseModel, "model_dump"):
+            return super().model_dump(*args, **kwargs)
+        return self.dict(*args, **kwargs)
+
 
 class Config(BaseModel):
     """Application configuration loaded from YAML or environment variables."""
@@ -27,6 +33,12 @@ class Config(BaseModel):
     qdrant_url: Optional[str] = None
     qdrant_api_key: Optional[str] = None
     embedding: EmbeddingConfig = EmbeddingConfig()
+
+    # Provide compatibility with pydantic v1
+    def model_dump(self, *args, **kwargs):  # type: ignore[override]
+        if hasattr(BaseModel, "model_dump"):
+            return super().model_dump(*args, **kwargs)
+        return self.dict(*args, **kwargs)
 
     @classmethod
     def load(cls, path: Path = CONFIG_FILE) -> "Config":
@@ -77,4 +89,7 @@ class Config(BaseModel):
     def save(self, path: Path = CONFIG_FILE) -> None:
         path.parent.mkdir(parents=True, exist_ok=True)
         with path.open("w") as f:
-            yaml.safe_dump(self.model_dump(), f)
+            if hasattr(self, "model_dump"):
+                yaml.safe_dump(self.model_dump(), f)
+            else:
+                yaml.safe_dump(self.dict(), f)


### PR DESCRIPTION
## Summary
- use `str(event.src_path)` when handling created and modified events
- ensure deletion and move events cast paths to strings
- make config compatible with pydantic v1

## Testing
- `ruff check .`
- `pyright code_index_engine/watcher.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68441c358c3483329a6a1fdc390dda84