### PR TITLE
Format devstral_eng.py with Black

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -1368,7 +1368,9 @@ def is_binary_file(file_path: str, peek_size: int = 1024) -> bool:
             return False
 
         # UTF-16/UTF-32 BOM detection
-        if chunk.startswith((b"\xff\xfe", b"\xfe\xff", b"\xff\xfe\x00\x00", b"\x00\x00\xfe\xff")):
+        if chunk.startswith(
+            (b"\xff\xfe", b"\xfe\xff", b"\xff\xfe\x00\x00", b"\x00\x00\xfe\xff")
+        ):
             try:
                 chunk.decode("utf-16")
                 return False


### PR DESCRIPTION
## Summary
- run `black devstral_eng.py`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684421ba9d1c83328b396a0a6666f08b