### PR TITLE
Improve error handling for tool calls

### DIFF
--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -1723,22 +1723,30 @@ async def _execute_tool(function_name: str, arguments: Dict[str, Any]) -> str:
 
 async def execute_function_call_dict(tool_call_dict) -> str:
     """Execute a function call from a dictionary format and return the result as a string."""
+    function_name = "unknown"
     try:
         function_name = tool_call_dict["function"]["name"]
         arguments = json.loads(tool_call_dict["function"]["arguments"])
         return await _execute_tool(function_name, arguments)
-
+    except KeyError as e:
+        return f"Malformed tool call dictionary: missing {e.args[0]}"
+    except json.JSONDecodeError as e:
+        return f"Invalid JSON arguments for {function_name}: {str(e)}"
     except Exception as e:
         return f"Error executing {function_name}: {str(e)}"
 
 
 async def execute_function_call(tool_call) -> str:
     """Execute a function call and return the result as a string."""
+    function_name = "unknown"
     try:
         function_name = tool_call.function.name
         arguments = json.loads(tool_call.function.arguments)
         return await _execute_tool(function_name, arguments)
-
+    except KeyError as e:
+        return f"Malformed tool call object: missing {e.args[0]}"
+    except json.JSONDecodeError as e:
+        return f"Invalid JSON arguments for {function_name}: {str(e)}"
     except Exception as e:
         return f"Error executing {function_name}: {str(e)}"
 

--- a/tests/test_execute_function_call.py
+++ b/tests/test_execute_function_call.py
@@ -1,0 +1,51 @@
+import ast
+import types
+from pathlib import Path
+import pytest
+
+# Load only execute_function_call_dict and execute_function_call from devstral_eng.py
+source = Path(__file__).resolve().parents[1] / "devstral_eng.py"
+mod_ast = ast.parse(source.read_text())
+fn_nodes = [
+    n
+    for n in mod_ast.body
+    if isinstance(n, ast.AsyncFunctionDef)
+    and n.name in {"execute_function_call_dict", "execute_function_call"}
+]
+module = types.ModuleType("_exec_funcs")
+module.__dict__["json"] = __import__("json")
+
+async def _execute_tool(name, args):
+    return f"{name}:{args}"
+
+module.__dict__["_execute_tool"] = _execute_tool
+exec(
+    compile(ast.Module(fn_nodes, []), filename=str(source), mode="exec"),
+    module.__dict__,
+)
+execute_function_call_dict = module.execute_function_call_dict
+execute_function_call = module.execute_function_call
+
+
+@pytest.mark.asyncio
+async def test_execute_function_call_dict_missing_key():
+    result = await execute_function_call_dict({})
+    assert "Malformed tool call dictionary" in result
+
+
+@pytest.mark.asyncio
+async def test_execute_function_call_dict_invalid_json():
+    data = {"function": {"name": "read_file", "arguments": "{"}}
+    result = await execute_function_call_dict(data)
+    assert "Invalid JSON arguments" in result
+
+
+class BadToolCall:
+    def __init__(self):
+        self.function = type("Func", (), {"name": "read_file", "arguments": "{"})
+
+
+@pytest.mark.asyncio
+async def test_execute_function_call_invalid_json_object():
+    result = await execute_function_call(BadToolCall())
+    assert "Invalid JSON arguments" in result


### PR DESCRIPTION
## Summary
- handle missing keys and invalid JSON in tool call helpers
- add tests for malformed tool call dictionaries and objects

## Testing
- `ruff check .`
- `pytest tests/test_execute_function_call.py -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684425b410e083328fdd10c6785f51dc