### PR TITLE
Add Textual TUI

### DIFF
--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -26,6 +26,11 @@ def main(
         "--debug",
         help="Debug output with profiling and engine logs",
     ),
+    tui: bool = typer.Option(
+        False,
+        "--tui",
+        help="Start the experimental Textual interface",
+    ),
     no_index: bool = typer.Option(
         False,
         "--no-index",
@@ -34,7 +39,12 @@ def main(
 ) -> None:
     """Start interactive chat when no subcommand is provided."""
     if ctx.invoked_subcommand is None:
-        chat(verbose=verbose, debug=debug, no_index=no_index)
+        if tui:
+            from .tui import run_tui
+
+            run_tui(verbose=verbose, debug=debug, no_index=no_index)
+        else:
+            chat(verbose=verbose, debug=debug, no_index=no_index)
 
 
 @app.command()

--- a/devstral_cli/tui.py
+++ b/devstral_cli/tui.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from typing import Any
+
+from rich.console import Console
+from textual.app import App, ComposeResult
+from textual.containers import Horizontal
+from textual.widgets import Input, TextLog
+
+import devstral_eng
+
+
+class _LogWriter:
+    """File-like bridge from Rich Console to a TextLog."""
+
+    def __init__(self, log: TextLog) -> None:
+        self.log = log
+
+    def write(self, data: str) -> None:  # pragma: no cover - simple passthrough
+        self.log.write(data)
+
+    def flush(self) -> None:  # pragma: no cover - interface requirement
+        pass
+
+
+class DevstralTUI(App):
+    """Textual UI displaying conversation history and assistant output."""
+
+    CSS = """
+    Screen { layout: vertical; }
+    #body { height: 1fr; }
+    #history, #output { width: 1fr; height: 1fr; border: round $secondary; }
+    #input { height: 3; }
+    """
+
+    BINDINGS = [("ctrl+c", "quit", "Quit")]
+
+    def __init__(self, *, no_index: bool = False) -> None:
+        super().__init__()
+        self.no_index = no_index
+        self._input_queue: asyncio.Queue[str] = asyncio.Queue()
+        self._engine_task: asyncio.Task[Any] | None = None
+
+    def compose(self) -> ComposeResult:  # pragma: no cover - textual runtime
+        with Horizontal(id="body"):
+            yield TextLog(id="history", highlight=True)
+            yield TextLog(id="output", highlight=True)
+        yield Input(placeholder="Message", id="input")
+
+    async def on_mount(self) -> None:  # pragma: no cover - textual runtime
+        self.history = self.query_one("#history", TextLog)
+        self.output = self.query_one("#output", TextLog)
+        self.input = self.query_one(Input)
+
+        # Redirect engine console output to the right pane
+        devstral_eng.console = Console(
+            file=_LogWriter(self.output),
+            force_terminal=True,
+            color_system="truecolor",
+        )
+
+        # Hook history updates
+        original_add = devstral_eng.add_to_history
+
+        def patched_add(message: dict[str, Any]) -> None:
+            original_add(message)
+            self.refresh_history()
+
+        devstral_eng.add_to_history = patched_add  # type: ignore[assignment]
+
+        # Replace prompt_session with queue-based input
+        async def get_input(_: str = "") -> str:
+            return await self._input_queue.get()
+
+        devstral_eng.prompt_session.prompt_async = get_input  # type: ignore[assignment]
+
+        self.refresh_history()
+        self._engine_task = asyncio.create_task(
+            devstral_eng.main(no_index=self.no_index)
+        )
+
+    def refresh_history(self) -> None:
+        self.history.clear()
+        for item in devstral_eng.conversation_history:
+            role = item.get("role")
+            content = item.get("content") or ""
+            self.history.write(f"{role}: {content}\n")
+
+    async def on_input_submitted(self, event: Input.Submitted) -> None:  # pragma: no cover - textual runtime
+        await self._input_queue.put(event.value)
+        self.input.value = ""
+
+    async def on_unmount(self) -> None:  # pragma: no cover - textual runtime
+        if self._engine_task:
+            self._engine_task.cancel()
+            with contextlib.suppress(Exception):
+                await self._engine_task
+
+
+def run_tui(*, verbose: bool = False, debug: bool = False, no_index: bool = False) -> None:
+    """Launch the Devstral textual interface."""
+
+    devstral_eng.VERBOSE = verbose
+    devstral_eng.DEBUG = debug
+    DevstralTUI(no_index=no_index).run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "beautifulsoup4>=4.12.3",
     "typer>=0.12.3",
     "questionary>=2.0.1",
+    "textual>=3.3.0",
     "numpy>=1.26.0",
     "pathspec>=0.12.1",
     "watchdog>=3.0.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,7 @@ aiohttp>=3.9.5
 beautifulsoup4>=4.12.3
 typer>=0.12.3
 questionary>=2.0.1
+textual>=3.3.0
 
 pathspec>=0.12.1
 watchdog>=3.0.0


### PR DESCRIPTION
## Summary
- create `tui.py` implementing a multi-pane interface with `textual`
- add `--tui` option to launch the new interface
- depend on `textual`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68443470b6fc8332b495bab86ec78d8e