### PR TITLE
Add search command for history

### DIFF
--- a/README.md
+++ b/README.md
@@ -354,6 +354,7 @@ devstral
 ```bash
 devstral history        # show saved conversation
 devstral clear-history  # remove saved conversation
+devstral history-search <term>  # search saved conversation
 ```
 
 ### Index Engine Commands

--- a/conversation_store.py
+++ b/conversation_store.py
@@ -42,3 +42,18 @@ def clear_history() -> None:
     """Remove the stored conversation history file."""
     if HISTORY_FILE.exists():
         HISTORY_FILE.unlink()
+
+
+def search_history(term: str) -> List[Dict[str, Any]]:
+    """Return conversation messages containing ``term`` (case-insensitive)."""
+    if not term:
+        return []
+    term = term.lower()
+    results: List[Dict[str, Any]] = []
+    for item in load_history():
+        try:
+            if term in json.dumps(item, ensure_ascii=False).lower():
+                results.append(item)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.debug("Failed to search message: %s", exc)
+    return results

--- a/devstral_cli/__init__.py
+++ b/devstral_cli/__init__.py
@@ -1,7 +1,8 @@
+import json
 import typer
 from config import Config, CONFIG_FILE
 from ddg_search import clear_ddg_cache
-from conversation_store import display_history, clear_history
+from conversation_store import display_history, clear_history, search_history
 from .chat import chat
 
 app = typer.Typer(
@@ -89,6 +90,16 @@ def clear_history_cmd() -> None:
     """Delete the stored conversation history."""
     clear_history()
     typer.echo("Conversation history cleared.")
+
+
+@app.command("history-search")
+def history_search_cmd(term: str) -> None:
+    """Search conversation history for messages containing TERM."""
+    matches = search_history(term)
+    if not matches:
+        typer.echo("No matching messages found.")
+    else:
+        typer.echo(json.dumps(matches, ensure_ascii=False, indent=2))
 
 
 @app.command("code-search")

--- a/tests/test_conversation_store.py
+++ b/tests/test_conversation_store.py
@@ -5,6 +5,7 @@ from conversation_store import (
     save_history,
     display_history,
     clear_history,
+    search_history,
 )
 
 
@@ -43,3 +44,16 @@ def test_corrupt_file_logs_warning(tmp_path, monkeypatch, caplog):
     assert any(
         "Failed to parse conversation history" in rec.message for rec in caplog.records
     )
+
+
+def test_search_history(tmp_path, monkeypatch):
+    file = tmp_path / "hist.json"
+    monkeypatch.setattr("conversation_store.HISTORY_FILE", file)
+    sample = [
+        {"role": "user", "content": "Hello there"},
+        {"role": "assistant", "content": "Hi"},
+        {"role": "user", "content": "Something else"},
+    ]
+    save_history(sample)
+    assert search_history("hello") == [sample[0]]
+    assert search_history("nothing") == []


### PR DESCRIPTION
## Summary
- allow searching saved conversation history
- extend CLI with `history-search` command
- document history search command
- test new search functionality

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844367c693c83328e970fb292f68e9c