### PR TITLE
Add slash command completion and history

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ For when you want to preload files into conversation context:
 - **Real-time streaming** with visible reasoning process
 - **Structured tables** for diff previews
 - **Progress indicators** for long operations
+- **Slash command auto-completion** and persistent command history
 
 ### 🛡️ **Security & Safety**
 - **Path normalization** and validation


### PR DESCRIPTION
## Summary
- improve interactive shell with persistent history and command completer
- document new shell behaviour in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_684448bab98c8332b2166d2bad3bfbad