### PR TITLE
Add basic API cost tracking

### DIFF
--- a/cost_tracker.py
+++ b/cost_tracker.py
@@ -1,0 +1,60 @@
+import time
+from typing import Dict, Any
+from rich.console import Console
+
+console = Console()
+
+# Track overall session metrics
+start_time = time.perf_counter()
+total_cost = 0.0
+total_api_duration = 0.0
+
+# Warning thresholds
+COST_WARNING = 5.0  # dollars
+DURATION_WARNING = 60.0  # seconds
+
+# Simple pricing table (USD per token)
+PRICING: Dict[str, Dict[str, float]] = {
+    "mistralai/devstral-small:free": {"prompt": 0.0, "completion": 0.0},
+    "openai/gpt-3.5-turbo": {"prompt": 0.0015 / 1000, "completion": 0.002 / 1000},
+    "openai/gpt-4": {"prompt": 0.03 / 1000, "completion": 0.06 / 1000},
+}
+
+
+def calculate_cost(model: str, usage: Dict[str, Any]) -> float:
+    """Return cost in USD for a response usage dictionary."""
+    if not usage:
+        return 0.0
+    pricing = PRICING.get(model)
+    if not pricing:
+        return 0.0
+    prompt_tokens = usage.get("prompt_tokens", 0)
+    completion_tokens = usage.get("completion_tokens", 0)
+    return (
+        prompt_tokens * pricing["prompt"] + completion_tokens * pricing["completion"]
+    )
+
+
+def add_cost(cost: float, duration: float) -> None:
+    """Accumulate cost and API duration, printing warnings if needed."""
+    global total_cost, total_api_duration
+    total_cost += cost
+    total_api_duration += duration
+    if total_cost >= COST_WARNING:
+        console.print(
+            f"[bold yellow]⚠ API cost warning: ${total_cost:.2f} spent[/bold yellow]"
+        )
+    if total_api_duration >= DURATION_WARNING:
+        console.print(
+            f"[bold yellow]⚠ API calls taking {total_api_duration:.1f}s so far[/bold yellow]"
+        )
+
+
+def format_cost_summary() -> str:
+    """Return a formatted cost summary for the session."""
+    elapsed = time.perf_counter() - start_time
+    return (
+        f"Total API cost: ${total_cost:.4f}\n"
+        f"Total API call duration: {total_api_duration:.2f}s\n"
+        f"Elapsed session time: {elapsed:.2f}s"
+    )

--- a/tests/test_cost_tracker.py
+++ b/tests/test_cost_tracker.py
@@ -1,0 +1,46 @@
+import sys
+import importlib
+import pytest
+
+import cost_tracker
+import conversation_store
+
+
+def test_add_cost_accumulates(monkeypatch):
+    monkeypatch.setattr(cost_tracker, "total_cost", 0.0)
+    monkeypatch.setattr(cost_tracker, "total_api_duration", 0.0)
+    cost_tracker.add_cost(0.5, 2.0)
+    cost_tracker.add_cost(1.0, 3.0)
+    assert cost_tracker.total_cost == 1.5
+    assert cost_tracker.total_api_duration == 5.0
+
+
+class DummySession:
+    async def prompt_async(self, prompt):
+        raise EOFError
+
+
+def reload_devstral(tmp_path, monkeypatch):
+    hist = tmp_path / "history.json"
+    monkeypatch.setattr(conversation_store, "HISTORY_FILE", hist)
+    sys.modules.pop("devstral_eng", None)
+    import devstral_eng
+    return importlib.reload(devstral_eng)
+
+
+@pytest.mark.asyncio
+async def test_session_prints_summary(tmp_path, monkeypatch):
+    eng = reload_devstral(tmp_path, monkeypatch)
+    monkeypatch.setattr(eng.Config, "load", classmethod(lambda cls: cls()))
+    monkeypatch.setattr(eng, "prompt_session", DummySession())
+    class FakeAI:
+        def __init__(self, *a, **k):
+            self.chat = type("Chat", (), {"completions": type("Comp", (), {"create": lambda *a, **k: None})()})()
+
+    monkeypatch.setattr(eng, "AsyncOpenAI", FakeAI)
+    printed = []
+    monkeypatch.setattr(eng.console, "print", lambda *a, **k: printed.append(" ".join(str(x) for x in a)))
+    monkeypatch.setattr(eng, "format_cost_summary", lambda: "SUMMARY")
+    await eng.main(no_index=True)
+    assert any("SUMMARY" in p for p in printed)
+


### PR DESCRIPTION
## Summary
- introduce `cost_tracker.py` for tracking API cost and duration
- update planner and streaming logic to record costs
- print a cost summary at session end
- test new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68445001198c8332af358eeab853d998