### PR TITLE
Improve README with startup and DEVSTRAL.md notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,6 +350,10 @@ or
 ```bash
 devstral
 ```
+When the chat starts you'll see a short environment summary showing the working
+directory, git status, platform, date and the default model. Keep your answers
+succinct (under four lines when possible) and run `devstral -h` at any time to
+view all CLI commands.
 
 ### History Commands
 ```bash
@@ -357,6 +361,13 @@ devstral history        # show saved conversation
 devstral clear-history  # remove saved conversation
 devstral history-search <term>  # search saved conversation
 ```
+
+### DEVSTRAL.md
+The assistant can record build or test commands and style notes in a
+`DEVSTRAL.md` file within your project. Approving prompts from functions like
+`record_build_command`, `record_test_command`, or `record_style_note` will append
+bulleted entries to this file so you have a handy reference for common tasks and
+guidelines.
 
 ### Index Engine Commands
 The code indexing engine is only started when `indexing_enabled` is `true` in

--- a/devstral_eng.py
+++ b/devstral_eng.py
@@ -33,7 +33,6 @@ import time
 import argparse
 import difflib
 from cost_tracker import add_cost, calculate_cost, format_cost_summary
-import platform
 from datetime import datetime
 
 # DuckDuckGo helper for on-demand web search


### PR DESCRIPTION
## Summary
- document the environment summary shown when launching `devstral`
- mention how DEVSTRAL.md records common commands and style preferences
- note that `devstral -h` shows help and keep replies concise
- remove unused import causing lint error

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684455cc4bf4833293f0067c1ff8a5cb