### PR TITLE
Add Qdrant tests

### DIFF
--- a/tests/test_qdrant_runtime.py
+++ b/tests/test_qdrant_runtime.py
@@ -1,0 +1,29 @@
+import devstral_cli.qdrant_runtime as qr
+
+
+def test_start_qdrant_missing_binary(monkeypatch):
+    monkeypatch.setattr(qr, "find_qdrant_binary", lambda: (_ for _ in ()).throw(FileNotFoundError()))
+    assert qr.start_qdrant() is None
+
+
+def test_start_qdrant_launch(monkeypatch, tmp_path):
+    started = {}
+
+    def fake_find():
+        path = tmp_path / "qd"
+        path.write_text("")
+        return path
+
+    class DummyProc:
+        def poll(self):
+            return None
+
+    def fake_popen(args, env=None, stdout=None, stderr=None):
+        started["args"] = args
+        return DummyProc()
+
+    monkeypatch.setattr(qr, "find_qdrant_binary", fake_find)
+    monkeypatch.setattr(qr.subprocess, "Popen", fake_popen)
+    proc = qr.start_qdrant(port=7000)
+    assert isinstance(proc, DummyProc)
+    assert started["args"] == [str(fake_find())]

--- a/tests/test_qdrant_store.py
+++ b/tests/test_qdrant_store.py
@@ -1,0 +1,56 @@
+from types import SimpleNamespace
+from dataclasses import dataclass
+import code_index_engine.qdrant_store as qs
+
+@dataclass
+class DummyPoint:
+    id: str
+    vector: list[float]
+    payload: dict[str, str]
+
+@dataclass
+class DummyIds:
+    points: list[str]
+
+class DummyClient:
+    def __init__(self, *a, **k):
+        self.collections = {}
+
+    def collection_exists(self, name):
+        return name in self.collections
+
+    def create_collection(self, collection_name, vectors_config):
+        self.collections[collection_name] = {}
+
+    def upsert(self, collection_name, points):
+        col = self.collections.setdefault(collection_name, {})
+        for p in points:
+            col[p.id] = (p.vector, p.payload)
+
+    def delete(self, collection_name, points_selector):
+        col = self.collections.get(collection_name, {})
+        for pid in points_selector.points:
+            col.pop(pid, None)
+
+    def search(self, collection_name, query_vector, limit):
+        import numpy as np
+        col = self.collections.get(collection_name, {})
+        results = []
+        for vec, payload in col.values():
+            score = float(np.dot(query_vector, vec) / (np.linalg.norm(query_vector)*np.linalg.norm(vec)+1e-6))
+            results.append(SimpleNamespace(payload=payload, score=score))
+        results.sort(key=lambda x: x.score, reverse=True)
+        return results[:limit]
+
+
+def test_qdrant_store_roundtrip(monkeypatch):
+    monkeypatch.setattr(qs, "QdrantClient", DummyClient)
+    monkeypatch.setattr(qs, "PointStruct", DummyPoint)
+    monkeypatch.setattr(qs, "PointIdsList", DummyIds)
+
+    store = qs.QdrantStore("http://local")
+    store.upsert("1", [0.0, 0.1], {"path": "a.py"})
+    hits = store.search([0.0, 0.1])
+    assert hits[0]["path"] == "a.py"
+    store.delete("1")
+    assert store.search([0.0, 0.1]) == []


### PR DESCRIPTION
## Summary
- add tests for QdrantStore
- add tests for the qdrant runtime helpers

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844c8aa71a48332a04b6dc7452faf7d