### PR TITLE
Fix release deb build path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,11 +27,12 @@ jobs:
         run: python -m build --sdist --wheel
       - name: Build .deb
         run: |
+          cd dist
           fpm -s python -t deb \
               --python-bin python3 \
               --name myapp \
               --version "${{ github.ref_name }}" \
-              dist/*.whl
+              *.whl
       - uses: actions/upload-artifact@v4
         with:
           name: deb


### PR DESCRIPTION
## Summary
- fix Debian package path in release workflow

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f7c5f2fc8332aa0329512d86696a