### PR TITLE
Fix .deb packaging in Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,11 +28,17 @@ jobs:
       - name: Build .deb
         run: |
           cd dist
-          fpm -s python -t deb \
-              --python-bin python3 \
+          version="${{ github.ref_name }}"
+          # Strip a leading 'v' from tag names for the package version
+          if [[ "$version" == v* ]]; then
+            version="${version#v}"
+          fi
+          mkdir pkgroot
+          python -m pip install --prefix=/usr --root=pkgroot *.whl
+          fpm -s dir -t deb \
               --name myapp \
-              --version "${{ github.ref_name }}" \
-              *.whl
+              --version "$version" \
+              -C pkgroot .
       - uses: actions/upload-artifact@v4
         with:
           name: deb


### PR DESCRIPTION
## Summary
- build `.deb` packages by installing wheel to staging dir
- keep tag version numbers consistent with package version

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844f9d022e483328f1bd928bc032a78