### PR TITLE
Fix release workflow Flatpak step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,12 @@ jobs:
         with:
           python-version: '3.x'
 
+      # Install tools required for building Flatpak bundles
+      - name: Install Flatpak dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y flatpak flatpak-builder xvfb
+
       # 2. Build .deb
       - name: Install build tools
         run: |


### PR DESCRIPTION
## Summary
- install flatpak-builder in release workflow to avoid missing command on Ubuntu 24.04

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68455887447483328838887ba34d7e78