### PR TITLE
Fix release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,50 +7,46 @@ on:
   workflow_dispatch:
 
 jobs:
-  release:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
 
-      # 1. Python setup
       - uses: actions/setup-python@v5
         with:
           python-version: '3.x'
 
-      # Install tools required for building Flatpak bundles
-      - name: Install Flatpak dependencies
+      - name: Install Flatpak deps
         run: |
           sudo apt-get update
           sudo apt-get install -y flatpak flatpak-builder xvfb
 
-      # 2. Build .deb
-      - name: Install build tools
-        run: |
-          python -m pip install --upgrade pip setuptools build
+      - name: Install Python build tools
+        run: python -m pip install --upgrade pip setuptools build
       - name: Install fpm
         run: sudo gem install --no-document fpm
-      - name: Build package
+      - name: Build sdist & wheel
         run: python -m build --sdist --wheel
       - name: Build .deb
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd dist
-          version="${{ github.ref_name }}"
-          # Strip a leading 'v' from tag names for the package version
-          if [[ "$version" == v* ]]; then
-            version="${version#v}"
-          fi
+          version="${GITHUB_REF#refs/tags/}"
+          version="${version#v}"
           mkdir pkgroot
           python -m pip install --prefix=/usr --root=pkgroot *.whl
           fpm -s dir -t deb \
-              --name myapp \
-              --version "$version" \
-              -C pkgroot .
+            --name myapp \
+            --version "$version" \
+            -C pkgroot .
       - uses: actions/upload-artifact@v4
         with:
           name: deb
-          path: 'dist/*.deb'
+          path: dist/*.deb
 
-      # 3. Build Flatpak
       - name: Add Flathub remote
         run: flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       - name: Build Flatpak
@@ -64,7 +60,6 @@ jobs:
           name: flatpak
           path: '*.flatpak'
 
-      # 4. Build AppImage
       - name: Build AppImage
         uses: AppImageCrafters/build-appimage@v1
         with:
@@ -74,16 +69,44 @@ jobs:
           name: appimage
           path: '*.AppImage'
 
-      # 5. Create Release and attach assets
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download Debian
+        uses: actions/download-artifact@v4
+        with:
+          name: deb
+      - name: Download Flatpak
+        uses: actions/download-artifact@v4
+        with:
+          name: flatpak
+      - name: Download AppImage
+        uses: actions/download-artifact@v4
+        with:
+          name: appimage
+
       - name: Create GitHub Release
+        id: create_release
         uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload Release Assets
+
+      - name: Upload release assets
         uses: softprops/action-gh-release@v1
         with:
-          files: '*.deb,*.flatpak,*.AppImage'
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          files: |
+            *.deb
+            *.flatpak
+            *.AppImage
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- refine the release workflow so Debian packaging and GitHub releases only run on tags
- fetch tags during checkout to set correct version values
- build artifacts in a dedicated job and create releases only from tagged runs

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'openai')*

------
https://chatgpt.com/codex/tasks/task_e_6845a3389d4c833280cbfe7073a33fc3