### PR TITLE
Fix Flatpak remote addition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
           path: dist/*.deb
 
       - name: Add Flathub remote
-        run: flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
+        run: sudo flatpak remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
       - name: Build Flatpak
         uses: flatpak/flatpak-github-actions/flatpak-builder@v6
         with:


### PR DESCRIPTION
## Summary
- fix the Add Flathub remote step in the release workflow

## Testing
- `ruff check .`
- `pytest -q` *(fails: ModuleNotFoundError for several modules)*

------
https://chatgpt.com/codex/tasks/task_e_6845ae59e4388332b8f73069b6079c49